### PR TITLE
Interface: Add examples of valid analyzer comments

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -17,7 +17,16 @@ The `analysis.json` file should be structured as followed:
 ```json
 {
   "status": "...",
-  "comments": []
+  "comments": [
+    {
+      "comment": "ruby.general.some_paramaterised_message",
+      "params": { "foo": "param1", "bar": "param2" }
+    }, 
+    {
+      "comment": "ruby.general.some_paramaterised_message"
+    },
+    "ruby.general.some_paramaterised_message"
+  ]
 }
 ```
 


### PR DESCRIPTION
RE @iHiD (https://github.com/exercism/automated-mentoring-support/issues/11#issuecomment-478092833):
> The following will be valid:

```
"comments": [
  {
    "comment": "ruby.general.some_paramaterised_message",
    "params": { "foo": "param1", "bar": "param2" }
  }, 
  {
    "comment": "ruby.general.some_paramaterised_message"
  },
  "ruby.general.some_paramaterised_message"
]
```