### PR TITLE
Small changes for interface doc

### DIFF
--- a/docs/interface.md
+++ b/docs/interface.md
@@ -51,5 +51,5 @@ Exercism is responsible for the display and communication of comments. The analy
 - While friendly, they should not try and pretend to be a human and should not contain greetings, etc.
 - The solution should not act like the start of a discussion.
 
-- A good comment would be "You could improve this solution by doing XYZ".
+- A good comment would be "This solution may be improved by doing XYZ".
 - A bad comment would be "Hello. Have you thought about doing XYZ?".

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -38,11 +38,11 @@ The following statuses are valid:
 
 ## Debugging
 
-The contents of stdout and stderr from each run will be persisted into files that can be viewed later.
+The contents of `stdout` and `stderr` from each run will be persisted into files that can be viewed later.
 
 You may write an `analysis.out` file that contains debugging information you want to later view.
 
-At a later date, we will provide an interface for you to download these files along with the submitted files and analysis.json.
+At a later date, we will provide an interface for you to download these files along with the submitted files and `analysis.json`.
 
 ## Comments
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -40,7 +40,7 @@ The following statuses are valid:
 
 The contents of stdout and stderr from each run will be persisted into files that can be viewed later.
 
-You may write an `analysis.out` file that contains and debugging information you want to later view.
+You may write an `analysis.out` file that contains debugging information you want to later view.
 
 At a later date, we will provide an interface for you to download these files along with the submitted files and analysis.json.
 

--- a/docs/interface.md
+++ b/docs/interface.md
@@ -21,7 +21,7 @@ The `analysis.json` file should be structured as followed:
     {
       "comment": "ruby.general.some_paramaterised_message",
       "params": { "foo": "param1", "bar": "param2" }
-    }, 
+    },
     {
       "comment": "ruby.general.some_paramaterised_message"
     },


### PR DESCRIPTION
- Remove extraneous whitespace
- Remove extra 'and'
- Make file references consistent
  - Early references surround with backticks while later references were without.
- Removes the personal reference in "good comment"