### PR TITLE
Specify the solution folder and entry point

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -4,5 +4,6 @@ Our analyzers are deployed as docker images.
 
 - Your dockerfile should live at the apex of your repository and it should be called `Dockerfile`
 - Your dockerfile should be be the minimal needed for your analyzer and create the minimal image needed for analysis. It should use alpine linux if possible.
-- The working directory should be `/opt/analyzer` (ie, we call `/opt/analyzer/analyze.sh`)
+- The working directory should be `/opt/analyzer` and an `ENTRYPOINT` should define the script to execute with the given parameters (e.g. `ENTRYPOINT ["/opt/analyzer/analyzer.sh"]`.
+- The students solution will be mapped to the folder `/solution` inside the docker container.
 - All changes to dockerfiles require a PR review from the core team.


### PR DESCRIPTION
I propose 2 changes here:

1) The folder the solution volume gets mapped to should be the same for each container so they can be called in the same way. E.g. `docker run -v ~/solutionxyz:/solution exercism/go-analyzer ...`. In this case this is "/solution".

We could even go so far as to say we remove the second parameter (solutions folder) from the `analyzer interface specification` as inside the container it would be "/solution" every time anyway.

2) The docker calling script does not need to know the entry point of the docker. This should be specified in the container with the `ENTRYPOINT` command. e.g. `ENTRYPOINT ["/opt/analyzer/analyzer.sh"]` or `ENTRYPOINT ["/opt/analyzer/analyzer"]`, etc.